### PR TITLE
Initial work on Open WebUI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 # IntelliJ IDEA
 .idea/*
+.github/instructions

--- a/bookmarklets/export.js
+++ b/bookmarklets/export.js
@@ -43,6 +43,25 @@
             csp = true;
             break;
         default:
+            let identifier;
+            // Open WebUI with the sidebar expanded
+            identifier = document.evaluate('//*/div[@id="sidebar"]/*/div[contains(@class, "sidebar")]//*[text() = "Open WebUI"]', document).iterateNext();
+            if (typeof identifier !== 'undefined' && identifier !== null) {
+                dialog = document.querySelector('[aria-labelledby="chat-conversation"]');
+                if (typeof dialog === 'object' && dialog !== null && typeof dialog.querySelectorAll !== 'undefined') {
+                    events = dialog.querySelectorAll('div.chat-user, div#response-content-container');
+                    break;
+                }
+            }
+            // Open WebUI with the sidebar closed
+            identifier = document.evaluate('//*/div[@id="sidebar"]//*/div/button[contains(@aria-label, "Open Sidebar")]', document).iterateNext();
+            if (typeof identifier !== 'undefined' && identifier !== null) { // there is no clear identifier...
+                dialog = document.querySelector('[aria-labelledby="chat-conversation"]');
+                if (typeof dialog === 'object' && dialog !== null && typeof dialog.querySelectorAll !== 'undefined') {
+                    events = dialog.querySelectorAll('div.chat-user, div#response-content-container');
+                    break;
+                }
+            }
             return alert(location.hostname + ' is not supported');
     }
     // Filter arrays


### PR DESCRIPTION
Hi,

I'm thinking of adding in support for Open WebUI instances.  Rather than using the host URL, this looks for the `"OpenWebUI"` moniker in the sidebar (on the assumption no one's modified their instance to say something else, that looks about the only reliable method).

In the main UI, user and model messages are held in `chat-user` and `response-content-container` divs, respectively.

The current version works only with the sidebar open.  Future work needs to:
- allow for other non-URL-based identity mechanisms
- fine-tune Open WebUI for closed sidebar handling

Here's a sample PDF:
[sample-open-webui-PDF.pdf](https://github.com/user-attachments/files/23130203/sample-open-webui-PDF.pdf)
